### PR TITLE
Update parts list,

### DIFF
--- a/docs/gettingStarted/buildGuide/partsList.rst
+++ b/docs/gettingStarted/buildGuide/partsList.rst
@@ -184,8 +184,8 @@ Hardware
 | |zipTies|                                                 | | **Zip ties**                                  |
 |                                                           | | Secures cables                                |
 +-----------------------------------------------------------+-------------------------------------------------+
-| |spring|                                                  | | **Speaker**                                   |
-|                                                           | | Produces sound                                |
+| |spring|                                                  | | **Spring**                                    |
+|                                                           | | Absorbs shock, stores and releases energy     |
 +-----------------------------------------------------------+-------------------------------------------------+
 | |cornerBracket|                                           | | **Corner bracket**                            |
 |                                                           | | Secures the Monitor                           |


### PR DESCRIPTION
 * change text to describe spring vs speaker

I did not see where the spring is used in the instructions, but I suspect it acts as a coil over spring on the shock absorbers.